### PR TITLE
sim: launch server and client with pid tracking

### DIFF
--- a/docs/Simulator.md
+++ b/docs/Simulator.md
@@ -20,8 +20,14 @@ Files:
 - `mplane_server/utils/test_shim/ServerTestShim.cpp`: UNIX socket daemon
 
 Scripts (tools/sim):
-- `sim_start.sh`, `sim_stop.sh` – start/stop shim
+- `sim_start.sh`, `sim_stop.sh` – start/stop shim, `mplane-server-app`, and `mplane_client`
 - `inject_alarm.sh`, `set_sync.sh`, `force_sw_result.sh`, `trigger_pm.sh` – helpers
+
+Environment variables:
+- `SIM_SHIM_BIN` – shim binary path
+- `SIM_SERVER_BIN` – `mplane-server-app` binary (default `build/server-sim/mplane-server-app`)
+- `SIM_CLIENT_BIN` – `mplane_client` command (default `mplane_client/build/mpc_client`)
+- `SIM_SHIM_PID_FILE`, `SIM_SERVER_PID_FILE`, `SIM_CLIENT_PID_FILE` – PID file locations
 
 Build (example):
 - Build halmplane for x86 (Yocto-style vars shown for clarity):
@@ -33,5 +39,5 @@ Build (example):
 - Start shim: `./tools/sim/sim_start.sh`
 
 Notes:
-- The shim does not start `mplane-server-app` or `mpc_client` automatically yet; see Tests.md for orchestration guidance.
+- `sim_start.sh` launches `mplane-server-app` and the `mplane_client` gRPC listener automatically; override paths via variables above.
 - When SW events are emitted with `slot=<name>`, the server updates `/o-ran-swm:software-inventory/software-slot[name='<name>']` status/active/running accordingly.

--- a/tools/sim/sim_start.sh
+++ b/tools/sim/sim_start.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-# Simple launcher for simulator shim only (server/client launch hooks TODO)
+# Simple launcher for simulator shim and optional server/client
 
 SOCK=/tmp/haltest.sock
 if [[ -S "$SOCK" ]]; then
@@ -13,4 +13,14 @@ echo "Starting server-test-shim..."
 "${SIM_SHIM_BIN:-mplane_server/utils/test_shim/build/server-test-shim}" &
 echo $! > "${SIM_SHIM_PID_FILE:-/tmp/server-test-shim.pid}"
 echo "Shim PID $(cat ${SIM_SHIM_PID_FILE:-/tmp/server-test-shim.pid})"
+
+echo "Starting mplane-server-app..."
+"${SIM_SERVER_BIN:-build/server-sim/mplane-server-app}" &
+echo $! > "${SIM_SERVER_PID_FILE:-/tmp/mplane-server-app.pid}"
+echo "Server PID $(cat ${SIM_SERVER_PID_FILE:-/tmp/mplane-server-app.pid})"
+
+echo "Starting mplane_client gRPC listener..."
+eval "${SIM_CLIENT_BIN:-mplane_client/build/mpc_client} &"
+echo $! > "${SIM_CLIENT_PID_FILE:-/tmp/mplane-client.pid}"
+echo "Client PID $(cat ${SIM_CLIENT_PID_FILE:-/tmp/mplane-client.pid})"
 

--- a/tools/sim/sim_stop.sh
+++ b/tools/sim/sim_stop.sh
@@ -1,12 +1,20 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-PID_FILE="${SIM_SHIM_PID_FILE:-/tmp/server-test-shim.pid}"
-if [[ -f "$PID_FILE" ]]; then
-  PID=$(cat "$PID_FILE")
-  echo "Stopping shim PID $PID"
-  kill "$PID" || true
-  rm -f "$PID_FILE"
-fi
+stop_proc() {
+  local pid_file="$1"
+  local label="$2"
+  if [[ -f "$pid_file" ]]; then
+    local pid=$(cat "$pid_file")
+    echo "Stopping $label PID $pid"
+    kill "$pid" || true
+    rm -f "$pid_file"
+  fi
+}
+
+stop_proc "${SIM_SERVER_PID_FILE:-/tmp/mplane-server-app.pid}" "server"
+stop_proc "${SIM_CLIENT_PID_FILE:-/tmp/mplane-client.pid}" "client"
+stop_proc "${SIM_SHIM_PID_FILE:-/tmp/server-test-shim.pid}" "shim"
+
 rm -f /tmp/haltest.sock || true
 


### PR DESCRIPTION
## Summary
- launch mplane-server-app and mplane_client in simulator start script
- record PIDs so stop script can cleanly shut them down
- document SIM_SERVER_BIN and SIM_CLIENT_BIN environment variables

## Testing
- `bash -n tools/sim/sim_start.sh`
- `bash -n tools/sim/sim_stop.sh`


------
https://chatgpt.com/codex/tasks/task_b_68b801097838832a97aef62fce56a99b