### PR TITLE
Add uplane TX ready simulator script

### DIFF
--- a/docs/Tests.md
+++ b/docs/Tests.md
@@ -9,7 +9,7 @@ Quickstart:
 - Start server (separate terminal): `build/server-sim/mplane-server-app --cfg-data-path <...> --netopeer-path <...> --yang-mods-path <...>`
 - Inject scenarios using helper scripts:
   - `./tools/sim/set_sync.sh LOCKED`
-  - `./tools/sim/uplane_tx_ready.sh <carrier>` (or use `uplane` command via `socat`)
+  - `./tools/sim/uplane_tx_ready.sh <carrier>`
   - `./tools/sim/inject_alarm.sh 1001 Major false "RF path warning"`
   - `./tools/sim/trigger_pm.sh RX_POWER /tmp`
 

--- a/tools/sim/uplane_tx_ready.sh
+++ b/tools/sim/uplane_tx_ready.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+CARRIER=${1:?carrier}
+printf 'uplane dir=tx name=%s state=ACTIVE\n' "$CARRIER" | socat - UNIX-CONNECT:/tmp/haltest.sock


### PR DESCRIPTION
## Summary
- add helper script to mark a TX carrier active via the shim
- document usage in test quickstart

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_b_68b80226dc04832aaece24f5344ecd0c