### PR TITLE
CI: launch stack and run sim tests

### DIFF
--- a/.github/workflows/sim-x86.yml
+++ b/.github/workflows/sim-x86.yml
@@ -25,16 +25,36 @@ jobs:
         run: |
           cmake -S mplane_server -B build/server-sim -DHAL_TEST=ON -DCMAKE_BUILD_TYPE=RelWithDebInfo
           cmake --build build/server-sim -j
-      - name: Start Shim
+      - name: Build mplane_client
         run: |
-          chmod +x tools/sim/*.sh
-          SIM_SHIM_BIN=mplane_server/utils/test_shim/build/server-test-shim ./tools/sim/sim_start.sh
-      - name: Sanity ping
+          cmake -S mplane_client -B mplane_client/build
+          cmake --build mplane_client/build -j
+      - name: Start simulator stack
         run: |
-          printf 'status\n' | socat - UNIX-CONNECT:/tmp/haltest.sock
-          printf 'sync state=LOCKED\n' | socat - UNIX-CONNECT:/tmp/haltest.sock
-          printf 'uplane dir=tx name=c1 state=ACTIVE\n' | socat - UNIX-CONNECT:/tmp/haltest.sock || true
-      - name: Stop Shim
+          SOCK=/tmp/haltest.sock
+          [ -S "$SOCK" ] && rm -f "$SOCK"
+          mplane_server/utils/test_shim/build/server-test-shim >shim.log 2>&1 &
+          echo $! > /tmp/server-test-shim.pid
+          build/server-sim/mplane-server-app >server.log 2>&1 &
+          echo $! > /tmp/mplane-server-app.pid
+          mplane_client/build/mpc_client --insecure >client.log 2>&1 &
+          echo $! > /tmp/mplane-client.pid
+          sleep 5
+      - name: Run tests
+        run: pytest -q tests/sim
+      - name: Stop simulator stack
         if: always()
         run: |
           ./tools/sim/sim_stop.sh || true
+      - name: Archive logs and PM files
+        if: always()
+        run: |
+          mkdir -p artifacts/logs artifacts/pm
+          cp shim.log server.log client.log artifacts/logs/ || true
+          find /tmp -name '*.csv' -exec cp {} artifacts/pm/ \; || true
+      - name: Upload artifacts
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: sim-artifacts
+          path: artifacts


### PR DESCRIPTION
## Summary
- start mplane-server-app and mplane_client in sim workflow
- run pytest suite and collect logs and PM artifacts

## Testing
- `pytest -q tests/sim` *(fails: ModuleNotFoundError: No module named 'grpc')*

------
https://chatgpt.com/codex/tasks/task_b_68b80f232430832aa0927cc50d148ab2