### PR TITLE
Build mplane_client in simulator tooling

### DIFF
--- a/docs/DevOnboarding-x86.md
+++ b/docs/DevOnboarding-x86.md
@@ -4,7 +4,7 @@ Prereqs (Ubuntu 22.04):
 - build-essential, cmake, socat
 - Optional: sysrepo/netopeer2, libyang, gRPC stack (for full server/client builds)
 
-Build HAL, shim, and server (with adapters):
+Build HAL, shim, server, and client (with adapters):
 - `./tools/sim/build_sim.sh`
 
 Run simulator:

--- a/docs/Simulator.md
+++ b/docs/Simulator.md
@@ -26,7 +26,7 @@ Scripts (tools/sim):
 Environment variables:
 - `SIM_SHIM_BIN` – shim binary path
 - `SIM_SERVER_BIN` – `mplane-server-app` binary (default `build/server-sim/mplane-server-app`)
-- `SIM_CLIENT_BIN` – `mplane_client` command (default `mplane_client/build/mpc_client`)
+- `SIM_CLIENT_BIN` – `mplane_client` command (default `build/client-sim/mpc_client`)
 - `SIM_SHIM_PID_FILE`, `SIM_SERVER_PID_FILE`, `SIM_CLIENT_PID_FILE` – PID file locations
 
 Build (example):
@@ -36,6 +36,9 @@ Build (example):
 - Build shim:
   - `cmake -S mplane_server/utils/test_shim -B mplane_server/utils/test_shim/build`
   - `cmake --build mplane_server/utils/test_shim/build -j`
+- Build client:
+  - `cmake -S mplane_client -B build/client-sim -DCMAKE_BUILD_TYPE=RelWithDebInfo`
+  - `cmake --build build/client-sim -j`
 - Start shim: `./tools/sim/sim_start.sh`
 
 Notes:

--- a/docs/Tests.md
+++ b/docs/Tests.md
@@ -4,7 +4,7 @@ Scope:
 - End-to-end tests will drive the stack via `mplane_client` gRPC and NETCONF RPCs. This repo now includes the simulator shim and mock HAL to make x86 testing feasible without hardware.
 
 Quickstart:
-- Build HAL, shim, and server with adapters: `./tools/sim/build_sim.sh`
+- Build HAL, shim, server, and client with adapters: `./tools/sim/build_sim.sh`
 - Start shim: `./tools/sim/sim_start.sh`
 - Start server (separate terminal): `build/server-sim/mplane-server-app --cfg-data-path <...> --netopeer-path <...> --yang-mods-path <...>`
 - Inject scenarios using helper scripts:

--- a/tests/sim/test_pm_remote.py
+++ b/tests/sim/test_pm_remote.py
@@ -26,7 +26,7 @@ NETCONF_PASS = os.getenv("MP_NETCONF_PASS", "oran")
 
 SIM_SHIM_BIN = Path(os.getenv("SIM_SHIM_BIN", "mplane_server/utils/test_shim/build/server-test-shim"))
 SIM_SERVER_BIN = Path(os.getenv("SIM_SERVER_BIN", "build/server-sim/mplane-server-app"))
-SIM_CLIENT_BIN = Path(os.getenv("SIM_CLIENT_BIN", "mplane_client/build/mpc_client"))
+SIM_CLIENT_BIN = Path(os.getenv("SIM_CLIENT_BIN", "build/client-sim/mpc_client"))
 
 
 def _spawn_with_log(cmd):

--- a/tests/sim/test_startup.py
+++ b/tests/sim/test_startup.py
@@ -25,7 +25,7 @@ CALLHOME_PORT = int(os.getenv("MP_CALLHOME_PORT", "4334"))
 
 SIM_SHIM_BIN = Path(os.getenv("SIM_SHIM_BIN", "mplane_server/utils/test_shim/build/server-test-shim"))
 SIM_SERVER_BIN = Path(os.getenv("SIM_SERVER_BIN", "build/server-sim/mplane-server-app"))
-SIM_CLIENT_BIN = Path(os.getenv("SIM_CLIENT_BIN", "mplane_client/build/mpc_client"))
+SIM_CLIENT_BIN = Path(os.getenv("SIM_CLIENT_BIN", "build/client-sim/mpc_client"))
 
 
 def _spawn_with_log(cmd):

--- a/tests/sim/test_uplane.py
+++ b/tests/sim/test_uplane.py
@@ -26,7 +26,7 @@ NETCONF_PASS = os.getenv("MP_NETCONF_PASS", "oran")
 
 SIM_SHIM_BIN = Path(os.getenv("SIM_SHIM_BIN", "mplane_server/utils/test_shim/build/server-test-shim"))
 SIM_SERVER_BIN = Path(os.getenv("SIM_SERVER_BIN", "build/server-sim/mplane-server-app"))
-SIM_CLIENT_BIN = Path(os.getenv("SIM_CLIENT_BIN", "mplane_client/build/mpc_client"))
+SIM_CLIENT_BIN = Path(os.getenv("SIM_CLIENT_BIN", "build/client-sim/mpc_client"))
 
 
 def _spawn_with_log(cmd):

--- a/tools/sim/build_sim.sh
+++ b/tools/sim/build_sim.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-# Build halmplane (x86) and mplane-server with HAL_TEST adapters
+# Build halmplane (x86), mplane-server with HAL_TEST adapters, and mplane_client
 
 ROOT_DIR=$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")/../.." &>/dev/null && pwd)
 
@@ -18,7 +18,13 @@ echo "[sim] Building mplane_server with HAL_TEST"
 cmake -S "$ROOT_DIR/mplane_server" -B "$ROOT_DIR/build/server-sim" -DHAL_TEST=ON -DCMAKE_BUILD_TYPE=RelWithDebInfo
 cmake --build "$ROOT_DIR/build/server-sim" -j
 
+echo "[sim] Building mplane_client"
+cmake -S "$ROOT_DIR/mplane_client" -B "$ROOT_DIR/build/client-sim" -DCMAKE_BUILD_TYPE=RelWithDebInfo
+cmake --build "$ROOT_DIR/build/client-sim" -j
+export SIM_CLIENT_BIN="$ROOT_DIR/build/client-sim/mpc_client"
+
 echo "[sim] Done. Binaries:"
 echo " - Shim: $ROOT_DIR/mplane_server/utils/test_shim/build/server-test-shim"
 echo " - Server: $ROOT_DIR/build/server-sim/mplane-server-app"
+echo " - Client: $SIM_CLIENT_BIN"
 

--- a/tools/sim/sim_start.sh
+++ b/tools/sim/sim_start.sh
@@ -20,7 +20,7 @@ echo $! > "${SIM_SERVER_PID_FILE:-/tmp/mplane-server-app.pid}"
 echo "Server PID $(cat ${SIM_SERVER_PID_FILE:-/tmp/mplane-server-app.pid})"
 
 echo "Starting mplane_client gRPC listener..."
-eval "${SIM_CLIENT_BIN:-mplane_client/build/mpc_client} &"
+eval "${SIM_CLIENT_BIN:-build/client-sim/mpc_client} &"
 echo $! > "${SIM_CLIENT_PID_FILE:-/tmp/mplane-client.pid}"
 echo "Client PID $(cat ${SIM_CLIENT_PID_FILE:-/tmp/mplane-client.pid})"
 


### PR DESCRIPTION
## Summary
- build mplane_client alongside HAL and server in `build_sim.sh`
- wire `sim_start.sh` and tests to use `build/client-sim/mpc_client`
- document client build steps and updated simulator defaults

## Testing
- `bash tools/sim/build_sim.sh` *(fails: Cannot find source file src/MplaneEcpri.c)*
- `pytest tests/sim/test_startup.py::test_mp_startup_001 -q`
- `pytest tests/sim/test_uplane.py::test_tx_carrier_ready -q`
- `pytest tests/sim/test_pm_remote.py::test_pm_remote_copy -q`


------
https://chatgpt.com/codex/tasks/task_b_68b80f318598832aa72f1575eca2a236